### PR TITLE
Add Flask-based geometry visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# analytical-geometry
+# Analytical Geometry Visualizer
+
+This project provides a small Flask web application to visualize the intersection of a line and a plane. It accepts LaTeX-style input and returns step-by-step calculations along with a generated 3D plot.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install flask sympy matplotlib antlr4-python3-runtime==4.11
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:5000` in a browser and enter your equations.
+
+The interface includes small buttons to help insert LaTeX snippets into the input fields.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,77 @@
+from flask import Flask, render_template, request, jsonify
+from sympy.parsing.latex import parse_latex
+from sympy import symbols, Eq, solve, lambdify, latex
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+import io
+import base64
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/solve', methods=['POST'])
+def solve_problem():
+    plane_latex = request.form.get('plane')
+    line_x_latex = request.form.get('line_x')
+    line_y_latex = request.form.get('line_y')
+    line_z_latex = request.form.get('line_z')
+
+    x, y, z, t = symbols('x y z t')
+
+    try:
+        plane_expr = parse_latex(plane_latex.replace('=', '-(') + ')')
+        line_x = parse_latex(line_x_latex.split('=')[1])
+        line_y = parse_latex(line_y_latex.split('=')[1])
+        line_z = parse_latex(line_z_latex.split('=')[1])
+    except Exception as e:
+        return jsonify({'error': f'Failed to parse input: {e}'})
+
+    plane_sub = plane_expr.subs({x: line_x, y: line_y, z: line_z})
+    t_value = solve(Eq(plane_sub, 0), t)
+    if not t_value:
+        return jsonify({'error': 'No intersection found.'})
+    t_value = t_value[0]
+
+    point = (line_x.subs(t, t_value), line_y.subs(t, t_value), line_z.subs(t, t_value))
+
+    steps = [
+        '1. Substitute the line parametric equations into the plane equation.',
+        f'2. Solve for $t$: {latex(Eq(plane_sub, 0))}',
+        f'3. Intersection point is {point}'
+    ]
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    xx, yy = np.meshgrid(range(-5, 6), range(-5, 6))
+    plane_lambda = lambdify((x, y), solve(plane_expr, z)[0], 'numpy')
+    zz = plane_lambda(xx, yy)
+    ax.plot_surface(xx, yy, zz, alpha=0.5)
+
+    t_vals = np.linspace(t_value-5, t_value+5, 50)
+    line_x_lambda = lambdify(t, line_x, 'numpy')
+    line_y_lambda = lambdify(t, line_y, 'numpy')
+    line_z_lambda = lambdify(t, line_z, 'numpy')
+    ax.plot(line_x_lambda(t_vals), line_y_lambda(t_vals), line_z_lambda(t_vals), 'r')
+
+    ax.scatter(*point, color='k', s=50)
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
+    ax.set_zlabel('z')
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    buf.seek(0)
+    img_b64 = base64.b64encode(buf.read()).decode('utf-8')
+    plt.close(fig)
+
+    return jsonify({'steps': steps, 'point': str(point), 'image': img_b64})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,22 @@
+document.getElementById('solve').addEventListener('click', function() {
+    const data = new FormData();
+    data.append('plane', document.getElementById('plane').value);
+    data.append('line_x', document.getElementById('line_x').value);
+    data.append('line_y', document.getElementById('line_y').value);
+    data.append('line_z', document.getElementById('line_z').value);
+    axios.post('/solve', data).then(res => {
+        if (res.data.error) {
+            document.getElementById('steps').innerText = res.data.error;
+            document.getElementById('plot').src = '';
+        } else {
+            document.getElementById('steps').innerHTML = res.data.steps.join('<br>');
+            document.getElementById('plot').src = 'data:image/png;base64,' + res.data.image;
+        }
+    });
+});
+
+function insert(id, text) {
+    const el = document.getElementById(id);
+    el.value += text;
+    el.focus();
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,5 @@
+body {font-family: Arial, sans-serif; margin: 20px;}
+.container {max-width: 600px; margin: auto;}
+.input-group {margin-bottom: 10px;}
+#steps {margin-top: 20px;}
+#plot {margin-top: 20px; max-width: 100%;}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Analytical Geometry Visualizer</title>
+<link rel="stylesheet" href="/static/style.css">
+<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+</head>
+<body>
+<div class="container">
+    <h1>Line and Plane Intersection</h1>
+    <div class="input-group">
+        <label>Plane (LaTeX):</label>
+        <input type="text" id="plane" placeholder="ax+by+cz+d=0">
+    </div>
+    <div class="input-group">
+        <label>Line x(t):</label>
+        <input type="text" id="line_x" placeholder="x=...">
+        <button onclick="insert('line_x','x=')">x=</button>
+    </div>
+    <div class="input-group">
+        <label>Line y(t):</label>
+        <input type="text" id="line_y" placeholder="y=...">
+        <button onclick="insert('line_y','y=')">y=</button>
+    </div>
+    <div class="input-group">
+        <label>Line z(t):</label>
+        <input type="text" id="line_z" placeholder="z=...">
+        <button onclick="insert('line_z','z=')">z=</button>
+    </div>
+    <button id="solve">Solve</button>
+    <div id="steps"></div>
+    <img id="plot" />
+</div>
+<script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up a simple Flask web app to visualize the intersection of a line and a plane
- add HTML/JS/CSS frontend
- document how to run the app

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68412ad44cf4832ea591d77998940378